### PR TITLE
quest error handling on character enter game

### DIFF
--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -14612,7 +14612,17 @@ break;
 
             VerifySpecPoints();
 
-            LoadQuests();
+            try
+            {
+                LoadQuests();
+            }
+            catch (Exception e)
+            {                
+                if (log.IsErrorEnabled)
+                {
+                    log.ErrorFormat("Problem loading quests for player {0} : {1}", Name, e);
+                }
+            }
 
             // Load Task object of player ...
             var tasks = GameServer.Database.SelectObjects<DBTask>("`Character_ID` = @Character_ID", new QueryParameter("@Character_ID", InternalID));


### PR DESCRIPTION
try catch statement when loading quests, to allow player to still load into game if there is a error loading their quests