### PR TITLE
disease delve

### DIFF
--- a/GameServer/spells/Spell.cs
+++ b/GameServer/spells/Spell.cs
@@ -449,7 +449,8 @@ namespace DOL.GS
 				case "ConstitutionBuff":
 				case "StrengthBuff":
 				case "DexterityBuff": return "stat";
-
+				
+				case "Disease": return "disease";
 				case "DamageOverTime": return "dot";
 
 				case "Confusion":
@@ -825,7 +826,7 @@ namespace DOL.GS
 				case "DirectDamageWithDebuff":
 				case "MesmerizeDurationBuff":
 				case "PaladinArmorFactorBuff":
-				
+				case "Disease": // this is disease strength decrease
 				case "ArmorFactorBuff": return (int)Value;
 
 				case "StyleSpeedDecrease": return (int)(100 - Value);
@@ -880,6 +881,7 @@ namespace DOL.GS
 				case "SummonNecroPet":
 				case "SummonTheurgistPet":
 				case "SummonUnderhill":
+				case "Disease": // this is disease speed decrease
 				case "DamageOverTime": return (int)Damage;
 
 				case "StrengthShear":


### PR DESCRIPTION
add proper tooltip delve for disease spells

For this to work, you need to add some values to the disease spell entry in the 'Spells' table
for the delve:
spell.damage = disease speed decrease
spell.value = disease strength reduction