### PR TITLE
animist fnf pet fix

### DIFF
--- a/GameServer/spells/Animist/SummonAnimistFnF.cs
+++ b/GameServer/spells/Animist/SummonAnimistFnF.cs
@@ -92,8 +92,7 @@ namespace DOL.GS.Spells
 
             ((TurretBrain) m_pet.Brain).IsMainPet = false;
 
-            ((IOldAggressiveBrain) m_pet.Brain)?.AddToAggroList(target, 1);
-            (m_pet.Brain as TurretBrain).Think();
+            ((IOldAggressiveBrain) m_pet.Brain)?.AddToAggroList(target, 1);            
 
             // [Ganrod] Nidel: Set only one spell.
             ((TurretPet) m_pet).TurretSpell = m_pet.Spells[0] as Spell;


### PR DESCRIPTION
Fix for fnf pets error on creation. Brain think method being called on creation in turn calls to check for the fnf pet in a dictionary its not added to yet. Problem stems from NPCCreate packet changes I made to prevent the client spamming server for NPCCreate/Update requests non stop. 
Thanks 'Eyeblaze' for reporting this bug.