### PR TITLE
fix long region names

### DIFF
--- a/GameServer/packets/Server/PacketLib1125.cs
+++ b/GameServer/packets/Server/PacketLib1125.cs
@@ -202,6 +202,10 @@ namespace DOL.GS.PacketHandler
                             {                                
                                 locationDescription = region.GetTranslatedSpotDescription(GameClient, c.Xpos, c.Ypos, c.Zpos);
                             }
+							if (locationDescription.Length > 23) // location name over 23 chars has to be truncated eg. "The Great Pyramid of Stygia"
+                            {
+                                locationDescription = (locationDescription.Substring(0, 20)) + "...";
+                            }
                             pak.WritePascalStringLowEndian(locationDescription);
 
                             string classname = "";


### PR DESCRIPTION
fix for long region names in char select screen. Max length sent is 23 characters. Truncate anything over this to 20 characters with a couple dots on the end for formatting