### PR TITLE
sendlogingranted fix

### DIFF
--- a/GameServer/packets/Server/PacketLib1125.cs
+++ b/GameServer/packets/Server/PacketLib1125.cs
@@ -58,7 +58,7 @@ namespace DOL.GS.PacketHandler
         }
 
         /// <summary>
-        /// 1125 logingranted
+        /// 1125 login granted		
         /// </summary>        
         public override void SendLoginGranted(byte color)
         {
@@ -66,9 +66,9 @@ namespace DOL.GS.PacketHandler
             {
                 pak.WritePascalString(GameClient.Account.Name);
                 pak.WritePascalString(GameServer.Instance.Configuration.ServerNameShort); //server name
-                pak.WriteByte(0x05); //Server ID
-                pak.WriteByte(0x07); // 03 gaheris type, 07 ywain type, 01 mordred type // TODO i need to check if this is relevant
-                pak.WriteByte(color);
+                pak.WriteByte(0x05); //Server ID, seems irrelevant
+                pak.WriteByte(color); // 00 normal type?, 01 mordred type, 03 gaheris type, 07 ywain type
+                pak.WriteByte(0x01); // always sent as 0x01 , unsure of significance
                 SendTCP(pak);
             }
         }


### PR DESCRIPTION
fix the handling of the 'color' byte. Very relevant as it determines whether the client (not the server) will disconnect a dual login on separate realms or not