### PR TITLE
fix for group members location on map

### DIFF
--- a/DOLServer/ConsolePacketLib.cs
+++ b/DOLServer/ConsolePacketLib.cs
@@ -203,9 +203,10 @@ namespace DOLGameServerConsole
 
         public void SendGroupWindowUpdate() { }
 
-        public void SendGroupMemberUpdate(bool updateIcons, GameLiving living) { }
+        public void SendGroupMemberUpdate(bool updateIcons, bool updateMap, GameLiving living) { }
 
         public void SendGroupMembersUpdate(bool updateIcons) { }
+        public void SendGroupMapUpdate(List<GroupMemberLocation> grpMembers) { }
 
         public void SendInventoryItemsUpdate(ICollection<InventoryItem> itemsToUpdate) { }
 

--- a/GameServer/packets/Client/168/PlayerInitRequestHandler.cs
+++ b/GameServer/packets/Client/168/PlayerInitRequestHandler.cs
@@ -97,8 +97,8 @@ namespace DOL.GS.PacketHandler.Client.v168
                 if (player.Group != null)
                 {
                     player.Group.UpdateGroupWindow();
-                    player.Group.UpdateAllToMember(player, true, false);
-                    player.Group.UpdateMember(player, true, true);
+                    player.Group.UpdateAllToMember(player, true, false, true);
+                    player.Group.UpdateMember(player, true, true, true);
                 }
 
                 player.Out.SendPlayerInitFinished(0);

--- a/GameServer/packets/Server/IPacketLib.cs
+++ b/GameServer/packets/Server/IPacketLib.cs
@@ -704,9 +704,10 @@ namespace DOL.GS.PacketHandler
 		void SendQuestSubscribeCommand(GameNPC invitingNPC, ushort questid, string inviteMessage);
 		void SendQuestAbortCommand(GameNPC abortingNPC, ushort questid, string abortMessage);
 		void SendGroupWindowUpdate();
-		void SendGroupMemberUpdate(bool updateIcons, GameLiving living);
+		void SendGroupMemberUpdate(bool updateIcons, bool updateMap, GameLiving living);
 		void SendGroupMembersUpdate(bool updateIcons);
-		void SendInventoryItemsUpdate(ICollection<InventoryItem> itemsToUpdate);
+        void SendGroupMapUpdate(List<GroupMemberLocation> grpMem);
+        void SendInventoryItemsUpdate(ICollection<InventoryItem> itemsToUpdate);
 		void SendInventorySlotsUpdate(ICollection<int> slots);
 		void SendInventoryItemsUpdate(eInventoryWindowType windowType, ICollection<InventoryItem> itemsToUpdate);
 		void SendInventoryItemsUpdate(IDictionary<int, InventoryItem> updateItems, eInventoryWindowType windowType);

--- a/GameServer/packets/Server/PacketLib1124.cs
+++ b/GameServer/packets/Server/PacketLib1124.cs
@@ -4865,7 +4865,7 @@ namespace DOL.GS.PacketHandler
 				}
 			}
 		}
-		protected virtual void WriteGroupMemberUpdate(GSTCPPacketOut pak, bool updateIcons, GameLiving living)
+		protected virtual void WriteGroupMemberUpdate(GSTCPPacketOut pak, bool updateIcons, bool updateMap, GameLiving living)
 		{
 			pak.WriteByte((byte)(living.GroupIndex + 1)); // From 1 to 8
 			bool sameRegion = living.CurrentRegion == GameClient.Player.CurrentRegion;
@@ -4925,7 +4925,7 @@ namespace DOL.GS.PacketHandler
 							}
 					}
 				}
-				WriteGroupMemberMapUpdate(pak, living);
+				WriteGroupMemberMapUpdate(pak, updateMap, living);
 			}
 			else
 			{
@@ -4937,10 +4937,10 @@ namespace DOL.GS.PacketHandler
 				}
 			}
 		}
-		protected virtual void WriteGroupMemberMapUpdate(GSTCPPacketOut pak, GameLiving living)
+		protected virtual void WriteGroupMemberMapUpdate(GSTCPPacketOut pak, bool updateMap, GameLiving living)
 		{
 			bool sameRegion = living.CurrentRegion == GameClient.Player.CurrentRegion;
-			if (sameRegion && living.CurrentSpeed != 0)//todo : find a better way to detect when player change coord
+			if (sameRegion && living.CurrentSpeed != 0 || updateMap)//todo : find a better way to detect when player change coord
 			{
 				Zone zone = living.CurrentZone;
 				if (zone == null)
@@ -5821,13 +5821,19 @@ namespace DOL.GS.PacketHandler
             }
         }        
 
-        public void SendGroupMemberUpdate(bool updateIcons, GameLiving living)
+        public void SendGroupMemberUpdate(bool updateIcons, bool updateMap, GameLiving living)
         {
             if (GameClient.Player == null)
+            {
                 return;
+            }
+
             Group group = GameClient.Player.Group;
+
             if (group == null)
+            {
                 return;
+            }
 
             using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.GroupMemberUpdate)))
             {
@@ -5835,8 +5841,11 @@ namespace DOL.GS.PacketHandler
                 {
                     // make sure group is not modified before update is sent else player index could change _before_ update
                     if (living.Group != group)
+                    {
                         return;
-                    WriteGroupMemberUpdate(pak, updateIcons, living);
+                    }
+
+                    WriteGroupMemberUpdate(pak, updateIcons, updateMap, living);
                     pak.WriteByte(0x00);
                     SendTCP(pak);
                 }
@@ -5854,8 +5863,43 @@ namespace DOL.GS.PacketHandler
             using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.GroupMemberUpdate)))
             {
                 foreach (GameLiving living in group.GetMembersInTheGroup())
-                    WriteGroupMemberUpdate(pak, updateIcons, living);
+                {
+                    WriteGroupMemberUpdate(pak, updateIcons, true, living);
+                }
+
                 pak.WriteByte(0x00);
+                SendTCP(pak);
+            }
+        }
+
+        public virtual void SendGroupMapUpdate(List<GroupMemberLocation> grpMembers)
+        {
+            if (GameClient.Player == null)
+            {
+                return;
+            }
+
+            using (GSTCPPacketOut pak = new GSTCPPacketOut((byte)eServerPackets.GroupMemberUpdate))
+            {
+                foreach (var member in grpMembers)
+                {
+                    if (GameClient.Player == member.grpMember)
+                    {
+                        if (grpMembers.Count == 1)
+                        {
+                            return; // same player and only one in the list, so return;
+                        }
+                        continue; // dont need to send yourself your own update, but more players in list to update so continue.
+                    }
+                    if (GameClient.Player.CurrentRegion == member.grpMember.CurrentRegion)
+                    {
+                        pak.WriteByte(member.GroupIndex);
+                        pak.WriteShort(member.ZoneID);
+                        pak.WriteShort(member.PlayerMapX);
+                        pak.WriteShort(member.PlayerMapY);
+                    }
+                }
+                pak.WriteByte(0x00); // null terminated
                 SendTCP(pak);
             }
         }

--- a/GameServer/packets/Server/PacketLib1125.cs
+++ b/GameServer/packets/Server/PacketLib1125.cs
@@ -417,7 +417,7 @@ namespace DOL.GS.PacketHandler
             }
         }			
 
-		protected override void WriteGroupMemberUpdate(GSTCPPacketOut pak, bool updateIcons, GameLiving living)
+		protected override void WriteGroupMemberUpdate(GSTCPPacketOut pak, bool updateIcons, bool updateMap, GameLiving living)
         {
             pak.WriteByte((byte)(0x20 | living.GroupIndex)); // From 1 to 8 // 0x20 is player status code
             bool sameRegion = living.CurrentRegion == GameClient.Player.CurrentRegion;
@@ -474,7 +474,7 @@ namespace DOL.GS.PacketHandler
                 // 0x00 = Normal , 0x01 = Dead , 0x02 = Mezzed , 0x04 = Diseased ,
                 // 0x08 = Poisoned , 0x10 = Link Dead , 0x20 = In Another Region, 0x40 - NS
 
-                WriteGroupMemberMapUpdate(pak, living); // moved here 
+                WriteGroupMemberMapUpdate(pak, updateMap, living); // moved here 
 
                 if (updateIcons)
                 {

--- a/UnitTests/TestPacketLib.cs
+++ b/UnitTests/TestPacketLib.cs
@@ -784,13 +784,13 @@ namespace DOL.Tests
             }
         }
 
-        public Action<TestPacketLib, bool, GameLiving> SendGroupMemberUpdateMethod { get; set; }
+        public Action<TestPacketLib, bool, bool, GameLiving> SendGroupMemberUpdateMethod { get; set; }
 
-        public void SendGroupMemberUpdate(bool updateIcons, GameLiving living)
+        public void SendGroupMemberUpdate(bool updateIcons, bool updateMap, GameLiving living)
         {
             if (SendGroupMemberUpdateMethod != null)
             {
-                SendGroupMemberUpdateMethod(this, updateIcons, living);
+                SendGroupMemberUpdateMethod(this, updateIcons, updateMap, living);
             }
         }
 
@@ -803,6 +803,8 @@ namespace DOL.Tests
                 SendGroupMembersUpdateMethod(this, updateIcons);
             }
         }
+
+        public void SendGroupMapUpdate(List<GroupMemberLocation> grpMembers) { }
 
         public Action<TestPacketLib, ICollection<InventoryItem>> SendInventoryItemsUpdateMethod { get; set; }
 


### PR DESCRIPTION
Preliminary commit for this. Needs some improvements but works for now. Tested with 3 players in group and appears to work fine on 1125, with small issue on 1124 . 
Things that might change:
callback timer frequency
method to check if player needs to broadcast an update
the amount of packets sent when a player joins a group