### PR TITLE
group map checks

### DIFF
--- a/GameServer/commands/playercommands/invite.cs
+++ b/GameServer/commands/playercommands/invite.cs
@@ -109,10 +109,15 @@ namespace DOL.GS.Commands
                     GroupMgr.AddGroup(group);
                     group.AddMember(client.Player);
                     group.AddMember(target);
+                    group.UpdateGroupWindow();
+                    group.SendGroupUpdates(client.Player);
+                    group.SendGroupUpdates(target);
                 }
                 else
                 {
                     client.Player.Group.AddMember(target);
+                    client.Player.Group.UpdateGroupWindow();
+                    client.Player.Group.SendGroupUpdates(target);
                 }
 
                 client.Out.SendMessage("(GM) You have added " + target.Name + " to your group.", eChatType.CT_System, eChatLoc.CL_SystemWindow);

--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -89,6 +89,12 @@ namespace DOL.GS
         /// Is this player being 'jumped' to a new location?
         /// </summary>
         public bool IsJumping { get; set; }
+        
+        /// <summary>
+        /// stores the players last updated map location that is sent to other group members
+        /// used when checking if a player has moved far enough to broadcast another map update
+        /// </summary>
+        public Point2D GroupMapOldLoc { get; set; }
 
         /// <summary>
         /// true if the targetObject is visible

--- a/GameServer/packets/Client/168/DialogResponseHandler.cs
+++ b/GameServer/packets/Client/168/DialogResponseHandler.cs
@@ -244,6 +244,8 @@ namespace DOL.GS.PacketHandler.Client.v168
                                     }
 
                                     groupLeader.Group.AddMember(player);
+                                    groupLeader.Group.UpdateGroupWindow();
+                                    groupLeader.Group.SendGroupUpdates(player);
                                     GameEventMgr.Notify(GamePlayerEvent.AcceptGroup, player);
                                     return;
                                 }
@@ -253,6 +255,9 @@ namespace DOL.GS.PacketHandler.Client.v168
 
                                 group.AddMember(groupLeader);
                                 group.AddMember(player);
+                                groupLeader.Group.UpdateGroupWindow();
+                                group.SendGroupUpdates(groupLeader);
+                                group.SendGroupUpdates(player);
 
                                 GameEventMgr.Notify(GamePlayerEvent.AcceptGroup, player);
                             }

--- a/GameServer/packets/Server/PacketLib1124.cs
+++ b/GameServer/packets/Server/PacketLib1124.cs
@@ -4940,8 +4940,8 @@ namespace DOL.GS.PacketHandler
 		protected virtual void WriteGroupMemberMapUpdate(GSTCPPacketOut pak, bool updateMap, GameLiving living)
 		{
 			bool sameRegion = living.CurrentRegion == GameClient.Player.CurrentRegion;
-			if (sameRegion && living.CurrentSpeed != 0 || updateMap)//todo : find a better way to detect when player change coord
-			{
+            if (updateMap || sameRegion && living.Group.CheckMemberNeedsUpdate((GamePlayer)living))
+            {
 				Zone zone = living.CurrentZone;
 				if (zone == null)
 					return;


### PR DESCRIPTION
Replaces old map update check that just checked for a player moving. This is a distance check, maybe not the best implementation though.
Also moved some of the update method calls to reduce some duplicate/redundant packets being sent when group members are added to group