### PR TITLE
fix teleporting in same region

### DIFF
--- a/GameServer/packets/Client/168/PlayerPositionUpdateHandler.cs
+++ b/GameServer/packets/Client/168/PlayerPositionUpdateHandler.cs
@@ -125,7 +125,8 @@ namespace DOL.GS.PacketHandler.Client.v168
 					client.Player.MaxLastZ = int.MinValue;
 				}
 				// Update water level and diving flag for the new zone
-				client.Out.SendPlayerPositionAndObjectID();				
+				// commenting this out for now, creates a race condition when teleporting within same region, jumping player back and forth as player xyz isnt updated yet.
+				//client.Out.SendPlayerPositionAndObjectID();				
 
 				/*
 				 * "You have entered Burial Tomb."


### PR DESCRIPTION
creates a race condition when teleporting within same region, jumping player back and forth as player xyz isnt updated yet.