### PR TITLE
update npc quest icon on level up

### DIFF
--- a/GameServer/gameobjects/GameNPC.cs
+++ b/GameServer/gameobjects/GameNPC.cs
@@ -2730,31 +2730,7 @@ namespace DOL.GS
             }
 
             return 0;
-        }
-
-        /// <summary>
-        /// Return the proper indicator for quest
-        /// TODO: check when finish indicator is set
-        /// * when you have done the NPC quest
-        /// * when you are at the last step
-        /// </summary>
-        /// <param name="questType">Type of quest</param>
-        /// <param name="player">player requesting the quest</param>
-        /// <returns></returns>
-        public eQuestIndicator SetQuestIndicator(Type questType, GamePlayer player)
-        {
-            if (CanShowOneQuest(player))
-            {
-                return eQuestIndicator.Available;
-            }
-
-            if (player.HasFinishedQuest(questType) > 0)
-            {
-                return eQuestIndicator.Finish;
-            }
-
-            return eQuestIndicator.None;
-        }
+        }        
 
         protected GameNPC m_teleporterIndicator = null;
 

--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -5886,6 +5886,15 @@ namespace DOL.GS
                 Task.SaveIntoDatabase();
             }
 
+            // see if npc in area can now show us a quest icon
+            foreach (GameNPC npc in GetNPCsInRadius(WorldMgr.VISIBILITY_DISTANCE))
+            {
+                if (npc.CanShowOneQuest(this))
+                {
+                    Out.SendNPCsQuestEffect(npc, eQuestIndicator.Available);
+                }
+            }
+
             // save player to database
             SaveIntoDatabase();
         }


### PR DESCRIPTION
adds check on player levelup to see if player now meets level requirement for quest giving npcs in area, and if so, updates their quest icon.
Remove unused quest icon method