### PR TITLE
fix 1127 release region change

### DIFF
--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -328,6 +328,11 @@ namespace DOL.GS
         }
 
         /// <summary>
+        /// Stores players objectId for use with the player revive packet - needed when changing region as player objectId is removed when they zone which is before SendPlayerRevive packet is sent
+        /// </summary>         
+        public ushort OldObjectId = 0;
+
+        /// <summary>
         /// Gets or sets the no help flag for this player
         /// (delegate to property in DBCharacter)
         /// </summary>
@@ -11410,6 +11415,7 @@ break;
 
             if (regionID != CurrentRegionID)
             {
+                OldObjectId = (ushort)this.ObjectID;
                 GameEventMgr.Notify(GamePlayerEvent.RegionChanging, this);
                 if (!RemoveFromWorld())
                 {

--- a/GameServer/packets/Server/PacketLib1124.cs
+++ b/GameServer/packets/Server/PacketLib1124.cs
@@ -6126,8 +6126,9 @@ namespace DOL.GS.PacketHandler
         {
             using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.PlayerRevive)))
             {
-                pak.WriteShort((ushort)revivedPlayer.ObjectID);
-                pak.WriteShort(0x00);
+				// when changing regions player.ObjectId will be sent as -1 - this causes issues with 1.127 so we need to send the stored OldObjectId instead
+				pak.WriteShort(revivedPlayer.ObjectID > 0 ? (ushort)revivedPlayer.ObjectID : (ushort)revivedPlayer.OldObjectId);
+				pak.WriteShort(0x00);
                 SendTCP(pak);
             }
         }


### PR DESCRIPTION
Fix for 1127 (and maybe 1126?) when releasing to a new region
Previously, server 0x89 packet would send the player.ObjectId as -1 when releasing to a new region , as when a player changes region, it is removed from the object array for that region and is not assigned a new objectId before the 0x89 is sent. This wasn't an issue on previous versions for whatever reason, but now the client replies with a 0xA9 packet, which will be filled with bogus data if it receives a bogus 0x89 packet.

This fix stores a players objectId when they change region and can then be used for this revive 0x89 packet, which now seems to fix this release bug